### PR TITLE
feat: Add strategy spec to chart

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/templates/deployment.yaml
+++ b/charts/core/templates/deployment.yaml
@@ -11,6 +11,13 @@ spec:
   selector:
     matchLabels:
       {{- include "dhis2-core-helm.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -31,6 +31,12 @@ readinessProbe:
 
 replicaCount: 1
 
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
 image:
   repository: dhis2/core
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Add `strategy` to Deployment template ([DeploymentStrategy API docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#deploymentstrategy-v1-apps)), so that the `RollingUpdate` configuration can be modified.