### PR TITLE
DEVOPS-180: use startupProbe for DHIS2 slow start

### DIFF
--- a/charts/core/templates/deployment.yaml
+++ b/charts/core/templates/deployment.yaml
@@ -69,6 +69,12 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          startupProbe:
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: http
           livenessProbe:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             httpGet:

--- a/charts/core/templates/deployment.yaml
+++ b/charts/core/templates/deployment.yaml
@@ -76,12 +76,10 @@ spec:
               path: {{ .Values.startupProbe.path }}
               port: http
           livenessProbe:
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             httpGet:
               path: {{ .Values.livenessProbe.path }}
               port: http
           readinessProbe:
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             httpGet:
               path: {{ .Values.readinessProbe.path }}
               port: http

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -27,10 +27,8 @@ startupProbe: # 2min10s (26 * 5 = 130s)
   periodSeconds: 5
   path: /
 livenessProbe:
-  initialDelaySeconds: 0
   path: /
 readinessProbe:
-  initialDelaySeconds: 0
   path: /
 
 replicaCount: 1

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -22,11 +22,15 @@ serverXml: config/server.xml
 catalinaOpts: "-Dcontext.path=''"
 javaOpts: ""
 
+startupProbe: # 2min10s (26 * 5 = 130s)
+  failureThreshold: 26
+  periodSeconds: 5
+  path: /
 livenessProbe:
-  initialDelaySeconds: 300
+  initialDelaySeconds: 0
   path: /
 readinessProbe:
-  initialDelaySeconds: 300
+  initialDelaySeconds: 0
   path: /
 
 replicaCount: 1

--- a/charts/core/values/dhis2.yaml
+++ b/charts/core/values/dhis2.yaml
@@ -7,11 +7,15 @@ ingress:
   path: /
   certIssuer: cert-issuer-prod
 catalinaOpts: "-Dcontext.path=/"
+startupProbe: # 2min10s (26 * 5 = 130s)
+  failureThreshold: 26
+  periodSeconds: 5
+  path: /
 livenessProbe:
-  initialDelaySeconds: 300
+  initialDelaySeconds: 0
   path: /
 readinessProbe:
-  initialDelaySeconds: 300
+  initialDelaySeconds: 0
   path: /
 dhisConfig: |
   connection.dialect = org.hibernate.dialect.PostgreSQLDialect

--- a/charts/core/values/dhis2.yaml
+++ b/charts/core/values/dhis2.yaml
@@ -12,10 +12,8 @@ startupProbe: # 2min10s (26 * 5 = 130s)
   periodSeconds: 5
   path: /
 livenessProbe:
-  initialDelaySeconds: 0
   path: /
 readinessProbe:
-  initialDelaySeconds: 0
   path: /
 dhisConfig: |
   connection.dialect = org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
liveness and readiness probes will only run after the startup probe was
successful. This is why initialDelaySeconds has been set to their
default of 0. If the startupProbe fails the restartPolicy kicks in and
restarts the container in DHIS2 pod.

DHIS2 seems to start within 1-2min in the current configuration on
kubernetes. Therefore a total time of 130s has been chosen. Startup
times might vary more, be shorter most of the time. We can fine tune
them in the stack or on deploy to find the best configuration.