### PR TITLE
refactor: update securityContext to match dhis2-core image

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -74,13 +74,14 @@ podLabels: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+   capabilities:
+     drop:
+     - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 65534
+   runAsGroup: 65534
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Update the default `securityContext` ([as done for the `im-manager`](https://github.com/dhis2-sre/im-manager/blob/master/helm/chart/values.yaml#L66)) to match the `nobody` Ubuntu user we also set for [the `dhis2-core` images](https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-web/dhis-web-portal/pom.xml#L167).