### PR TITLE
chore: set readOnlyRootFilesystem option to false

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.15.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -78,7 +78,7 @@ securityContext:
    capabilities:
      drop:
      - ALL
-   readOnlyRootFilesystem: true
+   readOnlyRootFilesystem: false # To be changed once dhis2-core and Tomcat are configured to log to stdout without needing write access.
    runAsNonRoot: true
    runAsUser: 65534
    runAsGroup: 65534


### PR DESCRIPTION
With the recent [update to the securityContext of this chart](https://github.com/dhis2-sre/dhis2-core-helm/pull/19) we started getting the following errors in the log (lines truncated for brevity):
```
...
java.io.FileNotFoundException: /usr/local/tomcat/logs/catalina.2023-05-22.log (Read-only file system)
...
java.io.FileNotFoundException: /usr/local/tomcat/logs/localhost.2023-05-22.log (Read-only file system)
...
java.io.FileNotFoundException: /usr/local/tomcat/logs/manager.2023-05-22.log (Read-only file system)
...
java.io.FileNotFoundException: /usr/local/tomcat/logs/host-manager.2023-05-22.log (Read-only file system)
...
22-May-2023 17:23:22.557 SEVERE [main] org.apache.jasper.EmbeddedServletOptions.<init> The scratchDir you specified: [/usr/local/tomcat/work/Catalina/localhost/pdw-5] is unusable.
22-May-2023 17:23:22.584 SEVERE [main] org.apache.catalina.valves.AccessLogValve.open Failed to open access log file [/usr/local/tomcat/logs/localhost_access_log.2023-05-22.txt] Note: running as user [nobody]
  java.io.FileNotFoundException: /usr/local/tomcat/logs/localhost_access_log.2023-05-22.txt (Read-only file system)
...
```

This PR sets `readOnlyRootFilesystem` option to `false` until Tomcat is configured to send logs to stdout.