### PR TITLE
fix: dhis.conf connection.schema should not be set DHIS2-18961

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -16,8 +16,6 @@ dhisConfig: |
   connection.url = jdbc:postgresql://dhis2-postgresql.dhis2.svc/dhis2
   connection.username = dhis
   connection.password = dhis
-  # Database schema behavior, can be validate, update, create, create-drop
-  connection.schema = update
   # Server base URL
   server.base.url = https://dhis2-core.127.0.0.1.nip.io/
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-18961

`connection.schema` should not have been exposed by dhis2-core as this allows users to put DHIS2 in an invalid state. The DB schema is entirely managed by flyway migrations. Hibernate auto DDL is only used during testing internally in dhis2-core.