### PR TITLE
feat: gateway api

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,53 @@ jobs:
       - name: Get nodes
         run: kubectl get nodes
 
+      - name: Install Gateway API CRDs
+        run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/${VERSION}/standard-install.yaml
+        env:
+          VERSION: v1.2.1
+
+      - name: Enable Gateway API provider on bundled Traefik
+        run: |
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: helm.cattle.io/v1
+          kind: HelmChartConfig
+          metadata:
+            name: traefik
+            namespace: kube-system
+          spec:
+            valuesContent: |-
+              providers:
+                kubernetesGateway:
+                  enabled: true
+              gateway:
+                enabled: false
+              gatewayClass:
+                enabled: true
+              rbac:
+                namespaced: false
+          EOF
+
+          # helm-controller reconciles the HelmChartConfig and re-runs helm upgrade
+          for i in {1..60}; do
+            if kubectl get gatewayclass traefik >/dev/null 2>&1; then
+              echo "GatewayClass traefik exists"
+              break
+            fi
+            echo "waiting for GatewayClass traefik..."
+            sleep 5
+          done
+
+          kubectl rollout status -n kube-system deployment/traefik --timeout=180s
+
+          for i in {1..30}; do
+            if [ "$(kubectl get gatewayclass traefik -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null)" = "True" ]; then
+              echo "GatewayClass traefik accepted"
+              break
+            fi
+            echo "waiting for GatewayClass traefik to be accepted..."
+            sleep 5
+          done
+
       - name: Install Helm and Sops
         uses: alexellis/arkade-get@master
         with:
@@ -45,6 +92,31 @@ jobs:
           VERSION: v2.6.0
           BINARY: skaffold-linux-amd64
 
+      - name: Create shared Gateway for HTTPRoute tests
+        run: |
+          kubectl create namespace dhis2 --dry-run=client -o yaml | kubectl apply -f -
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: Gateway
+          metadata:
+            name: dhis2-gateway
+            namespace: dhis2
+          spec:
+            gatewayClassName: traefik
+            listeners:
+              - name: http
+                protocol: HTTP
+                port: 80
+                allowedRoutes:
+                  namespaces:
+                    from: Same
+          EOF
+
+      - name: Deploy DHIS2 with Gateway API
+        run: |
+          cd tests/gateway/
+          ./../../skaffold run --status-check --wait-for-deletions
+
       - name: Deploy DHIS2 with FS
         run: |
           cd tests/fs/
@@ -61,7 +133,7 @@ jobs:
 
       - name: Verify endpoints
         env:
-          ENDPOINTS: "http://dhis2-127-0-0-1.nip.io/fs http://dhis2-127-0-0-1.nip.io/minio"
+          ENDPOINTS: "http://dhis2-127-0-0-1.nip.io/gateway http://dhis2-127-0-0-1.nip.io/fs http://dhis2-127-0-0-1.nip.io/minio"
         run: |
           for url in $ENDPOINTS; do
             echo "🔍 Checking $url"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,11 +28,6 @@ jobs:
       - name: Get nodes
         run: kubectl get nodes
 
-      - name: Install Gateway API CRDs
-        run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/${VERSION}/standard-install.yaml
-        env:
-          VERSION: v1.2.1
-
       - name: Enable Gateway API provider on bundled Traefik
         run: |
           cat <<'EOF' | kubectl apply -f -
@@ -106,7 +101,7 @@ jobs:
             listeners:
               - name: http
                 protocol: HTTP
-                port: 80
+                port: 8000
                 allowedRoutes:
                   namespaces:
                     from: Same

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.7
+version: 0.34.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.11
+version: 0.34.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.34.11](https://img.shields.io/badge/Version-0.34.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.34.10](https://img.shields.io/badge/Version-0.34.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 DHIS 2 Helm Chart
 

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.34.7](https://img.shields.io/badge/Version-0.34.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.34.8](https://img.shields.io/badge/Version-0.34.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 DHIS 2 Helm Chart
 
@@ -27,6 +27,15 @@ DHIS 2 Helm Chart
 | flyway.migrateOutOfOrder | bool | `false` | Allow out-of-order migrations |
 | flyway.repairBeforeMigration | bool | `false` | Repair before migrations |
 | fullnameOverride | string | `""` | Overrides the full name of the deployment (including namespace). |
+| gateway.enabled | bool | `false` | Whether to create HTTPRoute resources or not. |
+| gateway.hostname | string | `"dhis2-core.127.0.0.1.nip.io"` | Hostname the HTTPRoute matches on |
+| gateway.parentRefs | list | `[{"name":"dhis2-gateway"}]` | References to the Gateway(s) the HTTPRoute attaches to. See https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways |
+| gateway.routes | object | `{"glowroot":{"enabled":false,"path":"/glowroot","servicePort":4000},"main":{"path":"/","servicePort":8080}}` | HTTP routes configuration |
+| gateway.routes.glowroot.enabled | bool | `false` | Whether to enable Glowroot HTTP route |
+| gateway.routes.glowroot.path | string | `"/glowroot"` | Path for the Glowroot service |
+| gateway.routes.glowroot.servicePort | int | `4000` | Service port for the Glowroot service |
+| gateway.routes.main.path | string | `"/"` | Path for the main DHIS2 service |
+| gateway.routes.main.servicePort | int | `8080` | Service port for the main DHIS2 service |
 | glowroot.config | object | `{"gauges":[{"mbeanAttributes":[{"name":"HeapMemoryUsage.used"},{"name":"NonHeapMemoryUsage.used"}],"mbeanObjectName":"java.lang:type=Memory"}],"general":{"agentDisplayName":"DHIS2"},"ui":{"defaultGaugeNames":[],"defaultPercentiles":[50,95,99,99.9],"defaultTransactionType":"Web"},"web":{"bindAddress":"0.0.0.0","contextPath":"/glowroot","port":4000}}` | Glowroot configuration |
 | glowroot.enabled | bool | `false` | Whether to enable Glowroot or not. |
 | glowroot.expectedSha | string | `"7c7a46d8f0d020962f9299eb3c809a49d3156afb4ded46fae9088a603bc66fa3"` | Glowroot expected sha |

--- a/charts/core/templates/httproute-glowroot.yaml
+++ b/charts/core/templates/httproute-glowroot.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.gateway.enabled .Values.glowroot.enabled .Values.gateway.routes.glowroot.enabled -}}
+{{- $fullName := include "dhis2-core-helm.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-glowroot
+  labels:
+    {{- include "dhis2-core-helm.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - {{ .Values.gateway.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.gateway.routes.glowroot.path }}
+      backendRefs:
+        - name: {{ $fullName }}-glowroot
+          port: {{ .Values.gateway.routes.glowroot.servicePort }}
+{{- end }}

--- a/charts/core/templates/httproute.yaml
+++ b/charts/core/templates/httproute.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "dhis2-core-helm.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "dhis2-core-helm.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - {{ .Values.gateway.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.gateway.routes.main.path }}
+      backendRefs:
+        - name: {{ $fullName }}{{ if .Values.keda.enabled }}-keda-proxy{{ end }}
+          port: {{ .Values.gateway.routes.main.servicePort }}
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -290,6 +290,32 @@ ingress:
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
 
+# Gateway API HTTPRoute configuration (alternative to Ingress).
+# The Gateway itself is not managed by this chart and is expected to be
+# provisioned separately by the cluster operator.
+gateway:
+  # -- Whether to create HTTPRoute resources or not.
+  enabled: false
+  # -- Hostname the HTTPRoute matches on
+  hostname: dhis2-core.127.0.0.1.nip.io
+  # -- References to the Gateway(s) the HTTPRoute attaches to. See https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+  parentRefs:
+    - name: dhis2-gateway
+  # -- HTTP routes configuration
+  routes:
+    main:
+      # -- Path for the main DHIS2 service
+      path: /
+      # -- Service port for the main DHIS2 service
+      servicePort: 8080
+    glowroot:
+      # -- Whether to enable Glowroot HTTP route
+      enabled: false
+      # -- Path for the Glowroot service
+      path: /glowroot
+      # -- Service port for the Glowroot service
+      servicePort: 4000
+
 # KEDA is a Kubernetes-based Event Driven Autoscaling component
 # Only support Nginx ingress controller... Service type: ExternalName
 keda:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   k3s:
-    image: rancher/k3s:v1.31.1-k3s1
+    image: rancher/k3s:v1.33.12-k3s1
     privileged: true
     command: server
     ports:

--- a/tests/gateway/skaffold.yaml
+++ b/tests/gateway/skaffold.yaml
@@ -1,0 +1,56 @@
+apiVersion: skaffold/v4beta6
+kind: Config
+deploy:
+  statusCheckDeadlineSeconds: 420
+  helm:
+    releases:
+      - name: dhis2-gateway-postgresql
+        namespace: dhis2
+        createNamespace: true
+        remoteChart: postgresql
+        repo: https://charts.bitnami.com/bitnami
+        version: 11.9.8
+        valuesFiles:
+          - ./values/postgresql.yaml
+        setValueTemplates:
+          image:
+            repository: dhis2/postgresql-curl
+            pullPolicy: IfNotPresent
+            tag: 17
+          auth:
+            username: dhis
+            password: dhis
+            database: dhis2
+          persistence:
+            size: 5Gi
+
+      - name: dhis2-gateway-core
+        namespace: dhis2
+        createNamespace: true
+        chartPath: ../../charts/core
+        setValueTemplates:
+          database:
+            username: dhis
+            password: dhis
+            database: dhis2
+            hostname: dhis2-gateway-postgresql.dhis2.svc
+          gateway:
+            enabled: true
+            hostname: dhis2-127-0-0-1.nip.io
+            routes:
+              main:
+                path: /gateway
+            parentRefs:
+              - name: dhis2-gateway
+          startupProbe:
+            path: /gateway
+          livenessProbe:
+            path: /gateway
+          readinessProbe:
+            path: /gateway
+          contextPath: /gateway
+          image:
+            repository: dhis2/core-dev
+            # TODO: Should we actually target dev? At least configure this using an environment variable
+            tag: 2.42
+            pullPolicy: Always

--- a/tests/gateway/values/postgresql.yaml
+++ b/tests/gateway/values/postgresql.yaml
@@ -1,0 +1,1 @@
+../../postgresql.yaml


### PR DESCRIPTION
Add Gateway API HTTPRoute support to the chart as an alternative to the existing Ingress, plus an end-to-end test covering the new routing path.