### PR TITLE
fix: mount writable volume at /usr/local/tomcat/temp

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.7
+version: 0.34.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.34.7](https://img.shields.io/badge/Version-0.34.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.34.8](https://img.shields.io/badge/Version-0.34.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 DHIS 2 Helm Chart
 

--- a/charts/core/templates/deployment.yaml
+++ b/charts/core/templates/deployment.yaml
@@ -184,6 +184,8 @@ spec:
               subPath: server.xml
             - name: tomcat-logs
               mountPath: /usr/local/tomcat/logs
+            - name: tomcat-temp
+              mountPath: /usr/local/tomcat/temp
             - name: java-tmp
               mountPath: {{ .Values.javaTempDir }}
             {{- if .Values.glowroot.enabled }}
@@ -231,6 +233,8 @@ spec:
               - key: log4j2.xml
                 path: log4j2.xml
         - name: tomcat-logs
+          emptyDir: {}
+        - name: tomcat-temp
           emptyDir: {}
         - name: java-tmp
           emptyDir: {}


### PR DESCRIPTION
## Summary
- Add emptyDir mount at `/usr/local/tomcat/temp` so Tomcat's tmpdir is writable when `readOnlyRootFilesystem` is enabled.
- Bump chart patch version to `0.34.8`.

## Why
Tomcat's distroless entrypoint passes `-Djava.io.tmpdir=/usr/local/tomcat/temp` on the JVM command line, which overrides the value set via `JAVA_TOOL_OPTIONS` (`javaTempDir=/tmp/dhis`). With a read-only root filesystem this caused `BundledAppManager` to fail creating temp files:

```
ERROR org.hisp.dhis.appmanager.BundledAppManager [main] Fail to read app manifest from bundled app zip file, appName: 'cache-cleaner-app'
java.nio.file.FileSystemException: /usr/local/tomcat/temp/bundled-app-cache-cleaner-app...zip: Read-only file system
```

Verified against a live pod: `Command line argument: -Djava.io.tmpdir=/usr/local/tomcat/temp` confirms the entrypoint override; after the mount the error is gone.

## Test plan
- [x] `helm template` renders new `tomcat-temp` mount and volume
- [x] Deployed to `dhis2` namespace; `BundledAppManager` / read-only error no longer in logs