### PR TITLE
fix: mount writable volume at /usr/local/tomcat/work

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.8
+version: 0.34.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/templates/deployment.yaml
+++ b/charts/core/templates/deployment.yaml
@@ -186,6 +186,8 @@ spec:
               mountPath: /usr/local/tomcat/logs
             - name: tomcat-temp
               mountPath: /usr/local/tomcat/temp
+            - name: tomcat-work
+              mountPath: /usr/local/tomcat/work
             - name: java-tmp
               mountPath: {{ .Values.javaTempDir }}
             {{- if .Values.glowroot.enabled }}
@@ -235,6 +237,8 @@ spec:
         - name: tomcat-logs
           emptyDir: {}
         - name: tomcat-temp
+          emptyDir: {}
+        - name: tomcat-work
           emptyDir: {}
         - name: java-tmp
           emptyDir: {}


### PR DESCRIPTION
Installing an app from a zip fails with 
```
The temporary upload location [/usr/local/tomcat/work/Catalina/localhost/<context>] is not valid
``` 
because the pod runs with `readOnlyRootFilesystem: true` and no volume covers Tomcat's default workDir. 

This PR adds an emptyDir at `/usr/local/tomcat/work`, mirroring the temp-dir fix in #79.