### PR TITLE
feat: add structured JSON log4j2 config for Loki ingestion

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.9
+version: 0.34.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.34.8](https://img.shields.io/badge/Version-0.34.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.34.10](https://img.shields.io/badge/Version-0.34.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 DHIS 2 Helm Chart
 
@@ -70,7 +70,7 @@ DHIS 2 Helm Chart
 | keda.scalingMetric.requestRate.window | string | `"30s"` |  |
 | livenessProbe.path | string | `"/"` | Path |
 | livenessProbe.timeoutSeconds | int | `1` | Timeout in seconds |
-| log4j2 | string | `"config/log4j2.xml"` | Path to the log4j2 configuration file. |
+| log4j2 | string | `"config/log4j2.xml"` | Path to the log4j2 configuration file. Set to `config/log4j2-json.xml` for structured JSON logging suitable for log aggregators like Loki. |
 | minReadySeconds | int | `120` | Minimum number of seconds for the pod to be ready before being considered available. |
 | nameOverride | string | `""` | Overrides the chart's default name. |
 | nodeSelector | object | `{}` | Node selector labels that allow pods to be scheduled only onto nodes matching these labels. |

--- a/charts/core/config/log4j2-json.xml
+++ b/charts/core/config/log4j2-json.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <JsonTemplateLayout eventTemplateUri="classpath:LogstashJsonEventLayoutV1.json"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.hisp.dhis" level="INFO" additivity="true"/>
+
+        <Root level="WARN">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -171,7 +171,7 @@ dhis2Home: /opt/dhis2
 # -- Temporary directory for Java (used when readOnlyRootFilesystem is true).
 javaTempDir: /tmp/dhis
 
-# -- Path to the log4j2 configuration file.
+# -- Path to the log4j2 configuration file. Set to `config/log4j2-json.xml` for structured JSON logging suitable for log aggregators like Loki.
 log4j2: config/log4j2.xml
 
 # -- Path to the Tomcat server XML configuration file.


### PR DESCRIPTION
## Summary

Adds an opt-in `config/log4j2-json.xml` that emits each log event as a single JSON object via log4j2's `JsonTemplateLayout` (the `log4j-layout-template-json` artifact is already a dependency of dhis2-core). Users opt in by setting `log4j2: config/log4j2-json.xml` in values. Default behavior is unchanged.

The chosen template is the built-in `classpath:LogstashJsonEventLayoutV1.json` which produces flat top-level keys (`@timestamp`, `level`, `message`, `logger_name`, `thread_name`, `stack_trace`, and any MDC entries) that parse cleanly with LogQL `| json`.

Refs DEVOPS-398.

## Test plan

- [ ] Render with `log4j2: config/log4j2-json.xml` and confirm the ConfigMap contains the JSON-layout XML.
- [ ] Render with the default value and confirm no change to the existing log4j2 ConfigMap content.
- [ ] Deploy and confirm that pod logs are valid JSON with the expected keys.