### PR TITLE
feat: add NetworkPolicy support

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -73,6 +73,11 @@ DHIS 2 Helm Chart
 | log4j2 | string | `"config/log4j2.xml"` | Path to the log4j2 configuration file. Set to `config/log4j2-json.xml` for structured JSON logging suitable for log aggregators like Loki. |
 | minReadySeconds | int | `120` | Minimum number of seconds for the pod to be ready before being considered available. |
 | nameOverride | string | `""` | Overrides the chart's default name. |
+| networkPolicy.egress.additionalRules | list | `[]` | Additional custom egress rules appended to the policy. DNS (port 53) and PostgreSQL (port 5432) are always allowed. |
+| networkPolicy.enabled | bool | `false` | Whether to enable the NetworkPolicy resource. When enabled, only explicitly allowed traffic is permitted. |
+| networkPolicy.ingress.additionalRules | list | `[]` | Additional custom ingress rules appended to the policy. |
+| networkPolicy.ingress.ingressController | object | `{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"ingress-nginx"}},"podSelector":{"matchLabels":{"app.kubernetes.io/name":"ingress-nginx"}}}` | Selector for the nginx ingress controller pods. Adjust if your ingress controller runs in a different namespace or uses different labels. |
+| networkPolicy.ingress.keda | object | `{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"keda"}}}` | Namespace selector for the KEDA HTTP add-on interceptor proxy. Only applied when keda.enabled is true. |
 | nodeSelector | object | `{}` | Node selector labels that allow pods to be scheduled only onto nodes matching these labels. |
 | podAnnotations | object | `{}` | Annotations applied to all pods deployed by this chart. |
 | podLabels | object | `{}` | Labels applied to all pods deployed by this chart. |

--- a/charts/core/templates/networkpolicy.yaml
+++ b/charts/core/templates/networkpolicy.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "dhis2-core-helm.fullname" . }}
+  labels:
+    {{- include "dhis2-core-helm.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "dhis2-core-helm.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            {{- toYaml .Values.networkPolicy.ingress.ingressController.namespaceSelector | nindent 12 }}
+          podSelector:
+            {{- toYaml .Values.networkPolicy.ingress.ingressController.podSelector | nindent 12 }}
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+        {{- if .Values.glowroot.enabled }}
+        - port: {{ .Values.glowroot.port }}
+          protocol: TCP
+        {{- end }}
+    {{- if .Values.keda.enabled }}
+    - from:
+        - namespaceSelector:
+            {{- toYaml .Values.networkPolicy.ingress.keda.namespaceSelector | nindent 12 }}
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+    {{- end }}
+    {{- with .Values.networkPolicy.ingress.additionalRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - ports:
+        - port: 5432
+          protocol: TCP
+    {{- if hasKey .Values "minIO" }}
+    - ports:
+        - port: 9000
+          protocol: TCP
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.additionalRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -3,6 +3,29 @@
 # -- Common labels applied to all Kubernetes resources created by this chart.
 commonLabels: {}
 
+networkPolicy:
+  # -- Whether to enable the NetworkPolicy resource. When enabled, only explicitly allowed traffic is permitted.
+  enabled: false
+  ingress:
+    # -- Selector for the nginx ingress controller pods. Adjust if your ingress controller runs in a different namespace or uses different labels.
+    ingressController:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+    # -- Namespace selector for the KEDA HTTP add-on interceptor proxy. Only applied when keda.enabled is true.
+    keda:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: keda
+    # -- Additional custom ingress rules appended to the policy.
+    additionalRules: []
+  egress:
+    # -- Additional custom egress rules appended to the policy. DNS (port 53) and PostgreSQL (port 5432) are always allowed.
+    additionalRules: []
+
 #doris:
 #  hostname: doris.doris.svc
 #  port: 9030


### PR DESCRIPTION
## Summary

- Adds an opt-in `NetworkPolicy` resource (disabled by default) that enforces namespace isolation by denying all pod-to-pod traffic except what is explicitly allowed
- Ingress: nginx ingress controller (configurable namespace/pod selectors), KEDA interceptor proxy (when `keda.enabled=true`), Glowroot port when `glowroot.enabled=true`
- Egress: DNS (port 53), PostgreSQL (port 5432), MinIO (port 9000) when `minIO` is configured; extensible via `networkPolicy.ingress.additionalRules` / `networkPolicy.egress.additionalRules`

Closes [DEVOPS-142](https://dhis2.atlassian.net/browse/DEVOPS-142)

## Test plan

- [ ] `helm template` with `networkPolicy.enabled=true` renders a valid `NetworkPolicy`
- [ ] `helm template` without the flag renders no `NetworkPolicy` (no regression)
- [ ] Render with `keda.enabled=true` -- KEDA namespace ingress rule appears
- [ ] Render with `glowroot.enabled=true` -- Glowroot port included in ingress rule
- [ ] Render with `minIO` set -- port 9000 egress rule appears