### PR TITLE
fix: unescape literal \n in googleAuth.privateKey before toJson

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.10
+version: 0.34.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/templates/secrets.yaml
+++ b/charts/core/templates/secrets.yaml
@@ -48,7 +48,7 @@ data:
       "type" "service_account"
       "project_id" .Values.googleAuth.projectId
       "private_key_id" .Values.googleAuth.privateKeyId
-      "private_key" .Values.googleAuth.privateKey
+      "private_key" (.Values.googleAuth.privateKey | replace "\\n" "\n")
       "client_email" .Values.googleAuth.clientEmail
       "client_id" .Values.googleAuth.clientId
       "auth_uri" "https://accounts.google.com/o/oauth2/auth"


### PR DESCRIPTION
## Summary
- `toJson` re-escapes backslashes in `googleAuth.privateKey`, turning input `\n` into `\\n` in the rendered `dhis-google-auth.json`. DHIS2's PEM parser then fails to decode the key and Google Earth Engine map layers stop working.
- Pre-unescape literal `\n` before `toJson` so values stored with JSON-escape sequences and values with real newlines both produce a valid one-line-per-`\n` JSON string.
- Regression introduced by #65, where the file moved from a ConfigMap (raw interpolation) to a Secret (`dict | toJson`).

## Test plan
- [ ] Deploy a chart instance with `googleAuth.privateKey` containing literal `\n` sequences; confirm the decoded Secret has single-`\n` in `private_key` and that GEE map layers load.
- [ ] Deploy with a privateKey containing real newlines; confirm same output.